### PR TITLE
docs: synchronize project rules and release skill

### DIFF
--- a/.aiassistant/skills/lgs-1920-backend-release-deployment/SKILL.md
+++ b/.aiassistant/skills/lgs-1920-backend-release-deployment/SKILL.md
@@ -7,15 +7,32 @@ description: Prepare and validate LGS1920 backend releases, including version.js
 
 Use this skill for release and deployment work. Treat `version.json` as the current backend/API version source, not the legacy `package.json` version field, and inspect the generated artifact policy before changing `dist/`.
 
+## Shared issue and changelog policy
+
+- Treat `studio`, `site`, and `backend` as separate issue repositories. Use the repository that owns the change and link directly to that issue.
+- Never create or use a mirror issue in `studio` for a `site` or `backend` issue. For legacy mirrors, confirm ownership, remove references to the mirror from the owning issue and related documents, then delete only confirmed mirrors. Report ambiguous cases.
+- The public release changelog is maintained in the sibling Studio repository at `../studio/public/assets/changelog/` with the filename `YYYYMMDD-<version>.md`. If the target file is absent, create it automatically with today's date and the nearest existing file's header conventions.
+- Group closed issues and remaining bugs/features by owning repository. Omit empty repository headings and omit a category heading when it has no entries. Never include mirror links.
+
+### Changelog formatting
+
+- Use the exact filename `YYYYMMDD-<version>.md`, where `YYYYMMDD` is the release date and `<version>` is the exact version, including prerelease identifiers.
+- Before creating a missing file, inspect the nearest existing changelog in the same release line. Preserve its heading level, title style, section spelling, and blank-line conventions. Never overwrite an existing target file merely to normalize historical formatting.
+- The first heading must identify the release and its user-facing theme. Do not add a generated date line unless the established pattern for that release line includes one.
+- Render closed issues under `Closed Issues`, then render `Remaining Bugs` and `Remaining Features` only when entries exist. Within each category, group entries under `Studio`, `Site`, and `Backend` according to the owning repository.
+- Omit a repository heading when it has no entries in the category. Omit the category heading when no repository has entries. Do not render empty headings, placeholder text, or empty lists.
+- Preserve the issue title's meaning, correct only obvious formatting errors, and link every issue to its owning repository URL.
+
 ## Workflow
 
 1. Inspect `version.json`, `package.json`, `build.js`, `build.json`, `deploy.js`, `deployment/`, `servers.json`, and the current Git diff.
 2. Decide whether the change requires a version bump, dependency lock refresh, generated bundle, deployment configuration update, or only source changes.
 3. Validate semantic version format, confirm that `build.js --version` matches `version.json.backend`, and keep the API version stable unless the API contract intentionally changes.
-4. Build with the repository's Bun command and verify the output contains the expected entry point and configuration without committing secrets.
-5. Use the existing deployment platform selection (`production`, `staging`, or `test`) and inspect the resulting target before deploying.
-6. Verify version metadata, route registration, environment requirements, and generated artifact scope after the build.
-7. Report exact release files and uncommitted generated output. Do not deploy or publish without an explicit user request.
+4. Review shared release issue data and update the Studio public changelog when the backend change belongs to a shared release. Create the target file when absent, using today's date and the established header convention.
+5. Build with the repository's Bun command and verify the output contains the expected entry point and configuration without committing secrets.
+6. Use the existing deployment platform selection (`production`, `staging`, or `test`) and inspect the resulting target before deploying.
+7. Verify version metadata, route registration, environment requirements, and generated artifact scope after the build.
+8. Report exact release files and uncommitted generated output. Do not deploy or publish without an explicit user request.
 
 ## Release constraints
 

--- a/PROJECT_RULES.md
+++ b/PROJECT_RULES.md
@@ -56,7 +56,24 @@ This is the canonical source for the LGS1920 backend AI-agent and development ru
 - Never deploy, publish, or overwrite an existing versioned distribution without an explicit user request and a scope check.
 - Keep dependency manifests and the Bun lockfile synchronized when dependencies change.
 
-## 7. Git workflow
+## 7. Issue and release workflow
+
+### Cross-repository issue ownership
+
+- The managed repositories are `studio`, `site`, and `backend`. Create an issue in the repository that owns the API, service, or deployment change.
+- Never mirror a `site` or `backend` issue into `studio`. Record cross-repository dependencies with direct links to the owning issue; do not create duplicate issues.
+- During the mirror-removal migration, inventory confirmed `studio` mirrors of `backend` issues, transfer missing information to the owning issue, remove links to the mirror from the original issue and related documentation, and delete only unambiguous mirror issues.
+- Do not delete an issue with independent scope or unclear ownership. Report ambiguous cases for explicit user decision and verify that no active issue links to a deleted mirror.
+
+### Release and changelog workflow
+
+- Backend release notes participate in the shared public changelog maintained in the sibling Studio repository at `../studio/public/assets/changelog/`.
+- Use the filename `YYYYMMDD-<version>.md`, where `<version>` is the exact release version including prerelease identifiers. If the target file does not exist, create it automatically with today's date and the nearest existing changelog's header conventions.
+- Group closed issues and remaining open bugs/features by owning repository (`studio`, `site`, or `backend`). Omit empty repository headings and omit a category heading when it has no entries.
+- Link every issue to its owning repository. Never include mirror issue links or duplicate issue numbers.
+- Do not invent issue numbers, versions, dates, release membership, or user-facing outcomes.
+
+## 8. Git workflow
 
 - Create a commit only when the user explicitly requests one.
 - Use key-based commit prefixes: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, or `chore`.
@@ -65,16 +82,7 @@ This is the canonical source for the LGS1920 backend AI-agent and development ru
 - Never reset, checkout, or discard user changes without explicit authorization.
 - Report the exact commit scope and remaining working-tree changes after a commit.
 
-## 8. Issue workflow
-
-- Every open issue in this repository must have a corresponding issue in `lgs1920/studio`.
-- Create the Studio mirror as part of the same workflow when creating a new Backend issue.
-- The Studio mirror must use the same GitHub issue type as the source issue. If the source issue has no type, determine and set its correct type before creating the mirror.
-- Prefix the Studio mirror title with `[Backend]` and apply the lowercase `backend` label.
-- Add reciprocal cross-references between the Backend issue and its Studio mirror.
-- Before creating a mirror, search open and closed Studio issues for an existing reference to the Backend issue and reuse the existing mirror when one exists.
-
-## 9. Skill selection
+## 8. Skill selection
 
 - Use the `lgs-1920-backend-*` skills for backend files and backend-specific behavior.
 - Use the copied `lgs-1920-studio-*` skills only when the task explicitly crosses into Studio behavior or requires shared product context.


### PR DESCRIPTION
## Summary

- synchronize cross-repository issue ownership rules
- document mirror cleanup without duplicate issues
- standardize shared changelog naming, formatting, and conditional issue sections

## Validation

- git diff --check
- scoped documentation-only change

Unrelated working-tree changes were kept out of this branch.